### PR TITLE
added vpn disclaimer before submitting

### DIFF
--- a/pages/form/form.wxml
+++ b/pages/form/form.wxml
@@ -78,6 +78,8 @@
     <textarea placeholder="+86 185******" name="phone" class="input-contact" auto-height />
    </view>             
   </view>
+
+  <view class="label-details"> Tip: turn off vpn if unable to send </view>
   <button type="primary" form-type="submit" loading="{{loading}}">Send</button>
  </form>
 </view>

--- a/pages/wagon/wagon.js
+++ b/pages/wagon/wagon.js
@@ -9,7 +9,7 @@ Page({
     // Display toast if form success
     if(option.form == 1){
       wx.showToast({
-       title: 'FML added. Thanks!',
+       title: 'Review added. Thanks!',
        icon: 'success',
        duration: 3000
       });


### PR DESCRIPTION
User feedback that form submit was failing. Testing showed that leancloud requests time out when vpn is on. Gently reminding users to try turning off vpn if submit fails.